### PR TITLE
Fix issue when having '&' in password

### DIFF
--- a/peps_download.py
+++ b/peps_download.py
@@ -233,7 +233,7 @@ else:
 	tmticks=time.time()
 	tmpfile=("%s/tmp_%s.tmp")%(options.write_dir,tmticks)
 	print "\nDownload of product : %s"%prod
-	get_product='curl -o %s -k -u %s:%s https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps'%(tmpfile,email,passwd,options.collection,download_dict[prod])
+	get_product="curl -o %s -k -u '%s:%s' https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps"%(tmpfile,email,passwd,options.collection,download_dict[prod])
 	print get_product
 	if (not(options.no_download) and not(file_exists)):
             if storage_dict[prod]=="tape":


### PR DESCRIPTION
Protect authentication parameters (login:password) from being parsed by the shell, which cause a malformed curl command issue.