### PR TITLE
Shapefile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - pip install support
 - multipage requests
-- argument shape as file (shapefile, geojson, ...), shapely geometry, or geopandas object
+- argument shape bounding box: file (shapefile, geojson, ...), shapely geometry, or geopandas object
 - control of verbosity
 - NEWS.md for future updates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,16 @@
+# v1.0.0
+
+## Add
+
+- pip install support
+- multipage requests
+- argument shape as file (shapefile, geojson, ...), shapely geometry, or geopandas object
+- control of verbosity
+- NEWS.md for future updates
+
+
+# Change
+
+- return file status ('on tape', 'staging', 'on disk', 'downloaded', 'existing')
+ 
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,6 @@
 - control of verbosity
 - NEWS.md for future updates
 
-
 # Change
 
 - return file status ('on tape', 'staging', 'on disk', 'downloaded', 'existing')

--- a/README.md
+++ b/README.md
@@ -24,21 +24,21 @@ pip install git+https://github.com/floriandeboissieu/peps_download.git@shapefile
 This software is still quite basic, but if you have an account at PEPS, you may download products using command lines like 
 
 
-- `python ./peps_download.py  -c S2ST -l 'Toulouse' -a peps.txt -d 2017-01-01 -f 2017-02-01`
-- `python ./peps_download.py  -c S2ST -t 31TCJ -a peps.txt -d 2017-01-01 -f 2017-02-01`
+- `peps_download.py  -c S2ST -l 'Toulouse' -a peps.txt -d 2017-01-01 -f 2017-02-01`
+- `peps_download.py  -c S2ST -t 31TCJ -a peps.txt -d 2017-01-01 -f 2017-02-01`
 
  which downloads the *Sentinel-2 single tile* products  acquired in January 2017 above Toulouse (you may also specify the tile number as in the second example).
  When you provide a date YY-MM-DD, it is actually YY-MM-DD:00;00:00. So a request with `-d 2015-11-01 -f 2015-11-01` will yield no result, while `-d 2015-11-01 -f 2015-11-02` will yield data acquired on 2015-11-01 (provided they exist).
  
- - `python ./peps_download.py  -c S2ST --lon 1 --lat 43.5 -a peps.txt -d 2015-11-01 -f 2015-12-01 -o 51` 
+ - `peps_download.py  -c S2ST --lon 1 --lat 43.5 -a peps.txt -d 2015-11-01 -f 2015-12-01 -o 51` 
 
  which downloads the Sentinel-2 products above --lon 1 --lat 43.5 (~Toulouse), acquired in November 2015 from orbit path number 51 only.
 ### for Sentinel-1
-- `python ./peps_download.py  -c S1 --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a peps.txt -d 2015-11-01 -f 2015-12-01`
+- `peps_download.py  -c S1 --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a peps.txt -d 2015-11-01 -f 2015-12-01`
 
  which downloads the Sentinel-1 products in latitude, longitude box around Toulouse, acquired in November 2015.
 
-- `python ./peps_download.py -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01`
+- `peps_download.py -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01`
 which downloads S1 GRD products above Toulouse
 
 ### With python API

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This code relies on python 2.7 **(however, I just created a Python3 branch, whic
 
 Only the recent PEPS products or the frequently accessed ones are stored on disks (2 PB), while the rest is stored on tapes (up to 14 PB). Data stored on tapes have an access time increased by 2 to 6 mn. **From the 23rd of March, peps_download has been fully reshaped to first stage products on tapes for download, then download products on disk, which gives some time to upload the tape products on disks. This procedures considerably speeds the downloads up.**
  
+## Install
+
+```shell script
+pip install git+https://github.com/floriandeboissieu/peps_download.git@shapefile
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ This software is still quite basic, but if you have an account at PEPS, you may 
 - `python ./peps_download.py -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01`
 which downloads S1 GRD products above Toulouse
 
+### With python API
+
+```python
+from peps_download import peps_download
+write_dir = '/home/peps/my_peps_dl'
+auth = '/home/peps/peps.txt'
+files = peps_download(write_dir, auth, collection='S2ST', location='Toulouse', start_date='2017-01-01', end_date='2017-02-01')
+files = peps_download(write_dir, auth, collection='S2ST', tile='31TCJ', start_date='2017-01-01', end_date='2017-02-01', no_download=False)
+files = peps_download(write_dir, auth, collection='S2ST', shape='my_ROI.geojson', start_date='2017-01-01', end_date='2017-02-01')
+```
+
 ## Authentification 
 
 The file peps.txt must contain your email address and your password on the same line, such as:

--- a/peps_download.py
+++ b/peps_download.py
@@ -240,7 +240,7 @@ def parse_command_line():
 def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode="", no_download=True,
                   start_date=None, end_date=None, tile=None, location=None,
                   lat=None, lon=None, latmin=None, latmax=None, lonmin=None, lonmax=None,
-                  orbit=None, search_json_file=None, clouds=100, sat=None, extract=False,
+                  orbit=None, search_json_file=None, clouds=100, sat=None, extract=True,
                   max_trials=10, wait=1):
     """
     Download Sentinel S1, S2 or S3 products from PEPS sever

--- a/peps_download.py
+++ b/peps_download.py
@@ -277,8 +277,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         latitude or longitude in decimal degrees
     latmin,latmax,lonmin,lonmax: float
         bounding box of an area of interest
-    shape: str
-        Shape file used to define the extent, any format supported by geopandas
+    shape: str | geopandas.geodataframe.GeoDataFrame | geopandas.geoseries.GeoSeries
+        Shape file or object used to define the extent, any format supported by geopandas
     orbit: int
         Orbit Path number
     search_json_file: str
@@ -319,7 +319,16 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                     elif 'geopandas' not in sys.modules:
                         raise SysError('Package geopandas is needed to use argument "shape".', -1)
                     else:
-                        lonmin, latmin, lonmax, latmax = gpd.read_file(shape).to_crs(4326).total_bounds
+                        if isinstance(shape, str):
+                            if os.path.isfile(shape):
+                                shape = gpd.read_file(shape)
+                            else:
+                                raise SysError('Shape file not found', -1)
+
+                        if isinstance(shape, (gpd.geodataframe.GeoDataFrame, gpd.geoseries.GeoSeries)):
+                            lonmin, latmin, lonmax, latmax =shape.to_crs(4326).total_bounds
+                        else:
+                            raise SysError('Shape format not supported', -1)
 
                 geom = 'rectangle'
             else:

--- a/peps_download.py
+++ b/peps_download.py
@@ -259,9 +259,11 @@ def update_status(status_dict, downloaded_prod, write_dir):
 def statistics(status_dict, message=True):
     status = [v for k, v in status_dict.items()]
     summary = {}
+    total_to_download = 0
     for s in set(status):
         summary[s] = sum([v == s for v in status])
-        total_to_download = summary['on disk'] + summary['on tape'] + summary['staging']
+        if s in ['on disk', 'on tape', 'staging']:
+            total_to_download += summary[s]
 
     if message:
         print("###################################################")

--- a/peps_download.py
+++ b/peps_download.py
@@ -248,7 +248,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                   start_date=None, end_date=None, tile=None, location=None,
                   lat=None, lon=None, latmin=None, latmax=None, lonmin=None, lonmax=None, shape=None,
                   orbit=None, search_json_file=None, clouds=100, sat=None, extract=True,
-                  max_trials=10, wait=1):
+                  max_trials=10, wait=1, max_records=500):
     """
     Download Sentinel S1, S2 or S3 products from PEPS sever
 
@@ -296,6 +296,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         Maximum number of trials before it stops although files are still not downloaded (on tape or staging)
     wait: int
         Number of minutes to wait between trials.
+    max_records: int
+        Maximum number of products of request result
 
     Returns
     -------
@@ -424,11 +426,11 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     # search in catalog
     # ====================
     if (product_type == "") and (sensor_mode == ""):
-        search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500' % (
-            search_json_file, collection, query_geom, start_date, end_date)
+        search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=%d' % (
+            search_json_file, collection, query_geom, start_date, end_date, max_records)
     else:
-        search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
-            search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
+        search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=%d\&productType=%s\&sensorMode=%s' % (
+            search_json_file, collection, query_geom, start_date, end_date, max_records, product_type, sensor_mode)
 
     if os_platform.system() == 'Windows':
         search_catalog = search_catalog.replace('\&', '^&')
@@ -474,11 +476,11 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         while ((NbProdsToDownload > 0) and (n_trials < max_trials)):
             # redo catalog search to update disk/tape status
             if (product_type == "") and (sensor_mode == ""):
-                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500' % (
-                    search_json_file, collection, query_geom, start_date, end_date)
+                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=%d' % (
+                    search_json_file, collection, query_geom, start_date, end_date, max_records)
             else:
-                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
-                    search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
+                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=%d\&productType=%s\&sensorMode=%s' % (
+                    search_json_file, collection, query_geom, start_date, end_date, max_records, product_type, sensor_mode)
 
             if os_platform.system() == 'Windows':
                 search_catalog = search_catalog.replace('\&', '^&')

--- a/peps_download.py
+++ b/peps_download.py
@@ -310,7 +310,7 @@ def search_query(search_json_file, collection, product_type, sensor_mode,
     return download_dict, status_dict, size_dict
 
 
-def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode="", no_download=True,
+def peps_download(write_dir, auth="", collection='S2', product_type="", sensor_mode="", no_download=True,
                   start_date=None, end_date=None, tile=None, location=None,
                   lat=None, lon=None, latmin=None, latmax=None, lonmin=None, lonmax=None, shape=None,
                   orbit=None, search_json_file=None, clouds=100, sat=None, extract=True,
@@ -323,7 +323,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     write_dir: str
         Download directory
     auth: str
-        Authentication file with Peps account and password
+        Authentication file with Peps account and password, see example in peps.txt.
+        Not necessary if no_download=True.
     collection: str
         Collection within theia collections: 'S1', 'S2', 'S2ST', 'S3'
     product_type: str
@@ -471,18 +472,19 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             print("**** products after that date will be downloaded")
 
     # ====================
-    # read authentification file
+    # read authentication file
     # ====================
-    try:
-        f = open(auth)
-        (email, passwd) = f.readline().split(' ')
-        if passwd.endswith('\n'):
-            passwd = passwd[:-1]
-        f.close()
-    except Exception as e:
-        print(e)
-        SysError("error with authentication file", -2)
-        # sys.exit(-2)
+    if not no_download:  # auth not necessary for search query
+        try:
+            f = open(auth)
+            (email, passwd) = f.readline().split(' ')
+            if passwd.endswith('\n'):
+                passwd = passwd[:-1]
+            f.close()
+        except Exception as e:
+            print(e)
+            SysError("error with authentication file", -2)
+            # sys.exit(-2)
 
     if os.path.exists(search_json_file):
         os.remove(search_json_file)

--- a/peps_download.py
+++ b/peps_download.py
@@ -489,36 +489,6 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     print("##########################")
     n_trials = 0
     while ((NbProdsToDownload > 0) and (n_trials < max_trials)):
-        # redo catalog search to update disk/tape status
-        page = 0
-        download_dict = {}
-        storage_dict = {}
-        size_dict = {}
-        page_len = 500
-        while page_len == 500:
-            page += 1
-            print('Page {}:'.format(str(page)))
-            if (product_type == "") and (sensor_mode == ""):
-                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&page=%d' % (
-                    search_json_file, collection, query_geom, start_date, end_date, page)
-            else:
-                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s\&page=%d' % (
-                    search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode, page)
-
-            if os_platform.system() == 'Windows':
-                search_catalog = search_catalog.replace('\&', '^&')
-
-            print(search_catalog)
-            os.system(search_catalog)
-            time.sleep(5)
-
-            dl_dict, st_dict, si_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
-            download_dict.update(dl_dict)
-            storage_dict.update(st_dict)
-            size_dict.update(si_dict)
-            page_len = len(dl_dict)
-
-        products = list(download_dict.keys())
         NbProdsToDownload = 0
         # download all products on disk
         for prod in products:
@@ -551,7 +521,36 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                   (NbProdsToDownload, wait))
             print("##############################################################################")
             time.sleep(wait*60)
+            # redo catalog search to update disk/tape status
+            page = 0
+            download_dict = {}
+            storage_dict = {}
+            size_dict = {}
+            page_len = 500
+            while page_len == 500:
+                page += 1
+                print('Page {}:'.format(str(page)))
+                if (product_type == "") and (sensor_mode == ""):
+                    search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&page=%d' % (
+                        search_json_file, collection, query_geom, start_date, end_date, page)
+                else:
+                    search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s\&page=%d' % (
+                        search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode, page)
 
+                if os_platform.system() == 'Windows':
+                    search_catalog = search_catalog.replace('\&', '^&')
+
+                print(search_catalog)
+                os.system(search_catalog)
+                time.sleep(5)
+
+                dl_dict, st_dict, si_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+                download_dict.update(dl_dict)
+                storage_dict.update(st_dict)
+                size_dict.update(si_dict)
+                page_len = len(dl_dict)
+
+            products = list(download_dict.keys())
 
     return products
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -467,7 +467,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             os.system(search_catalog)
             time.sleep(2)
 
-            products, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+            _, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
 
             NbProdsToDownload = 0
             # download all products on disk

--- a/peps_download.py
+++ b/peps_download.py
@@ -181,14 +181,13 @@ def parse_command_line():
         print('      ' + sys.argv[0] + ' [options]')
         print("     Aide : ", prog, " --help")
         print("        ou : ", prog, " -h")
-        print("example 1 : python %s -l 'Toulouse' -a peps.txt -d 2016-12-06 -f 2017-02-01 -c S2ST" %
+        print("example 1 : python %s -l 'Toulouse' -a peps.txt -d 2016-12-06 -f 2017-02-01 -c S2" %
               sys.argv[0])
         print("example 2 : python %s --lon 1 --lat 44 -a peps.txt -d 2015-11-01 -f 2015-12-01 -c S2" %
               sys.argv[0])
         print("example 3 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a peps.txt -d 2015-11-01 -f 2015-12-01 -c S2" %
               sys.argv[0])
-        print("example 4 : python %s -l 'Toulouse' -a peps.txt -c SpotWorldHeritage -p SPOT4 -d 2005-11-01 -f 2006-12-01" %
-              sys.argv[0])
+
         print("example 5 : python %s -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01" %
               sys.argv[0])
         sys.exit(-1)
@@ -200,6 +199,7 @@ def parse_command_line():
                           help="Peps account and password file")
         parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
                           help="Path where the products should be downloaded", default='.')
+        # S2ST kept for retrocompatibility (see commit bb66f9e, 2020-12-20)
         parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
                           help="Collection within theia collections", choices=['S1', 'S2', 'S2ST', 'S3'], default='S2')
         parser.add_option("-p", "--product_type", dest="product_type", action="store", type="string",
@@ -333,7 +333,7 @@ def peps_download(write_dir, auth="", collection='S2', product_type="", sensor_m
         Authentication file with Peps account and password, see example in peps.txt.
         Not necessary if no_download=True.
     collection: str
-        Collection within theia collections: 'S1', 'S2', 'S2ST', 'S3'
+        Collection within theia collections: 'S1', 'S2', 'S3'
     product_type: str
         GRD, SLC, OCN (for S1) | S2MSI1C S2MSI2A S2MSI2Ap (for S2)
     sensor_mode:
@@ -460,23 +460,10 @@ def peps_download(write_dir, auth="", collection='S2', product_type="", sensor_m
 
     # special case for Sentinel-2
 
+    # All tiles available in S2ST (see commit bb66f9e, 2020-12-20)
+    # for retrocompatibility
     if collection == 'S2':
-        if start_date >= '2016-12-05':
-            print("**** products after '2016-12-05' are stored in Tiled products collection")
-            print("**** please use option -c S2ST")
-        elif end_date >= '2016-12-05':
-            print("**** products after '2016-12-05' are stored in Tiled products collection")
-            print("**** please use option -c S2ST to get the products after that date")
-            print("**** products before that date will be downloaded")
-
-    if collection == 'S2ST':
-        if end_date < '2016-12-05':
-            print("**** products before '2016-12-05' are stored in non-tiled products collection")
-            print("**** please use option -c S2")
-        elif start_date < '2016-12-05':
-            print("**** products before '2016-12-05' are stored in non-tiled products collection")
-            print("**** please use option -c S2 to get the products before that date")
-            print("**** products after that date will be downloaded")
+        collection = 'S2ST'
 
     # ====================
     # read authentication file

--- a/peps_download.py
+++ b/peps_download.py
@@ -564,7 +564,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                                                                      query_geom, orbit, clouds, sat, verbose=verbose)
                 products = list(download_dict.keys())
                 status_dict = update_status(status_dict, downloaded_prod, write_dir)
-                summary, total_to_download = statistics(status_dict, message=True)
+                summary, total_to_download = statistics(status_dict, message=verbose)
 
     return status_dict
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -160,7 +160,7 @@ def parse_catalog(search_json_file, orbit, collection, clouds, sat):
         return {}, {}, {}, {}
 #    print(download_dict.keys())
 
-    return(prod, download_dict, storage_dict, size_dict)
+    return(download_dict, storage_dict, size_dict)
 
 
 # ===================== MAIN
@@ -419,7 +419,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     os.system(search_catalog)
     time.sleep(5)
 
-    products, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+    download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+    products = download_dict.keys()
 
     # ====================
     # Download
@@ -467,7 +468,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             os.system(search_catalog)
             time.sleep(2)
 
-            _, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+            download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
 
             NbProdsToDownload = 0
             # download all products on disk

--- a/peps_download.py
+++ b/peps_download.py
@@ -552,6 +552,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                     search_catalog = search_catalog.replace('\&', '^&')
 
                 print(search_catalog)
+                if os.path.exists(search_json_file):
+                    os.remove(search_json_file)
                 os.system(search_catalog)
                 time.sleep(5)
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -222,7 +222,7 @@ def parse_command_line():
         parser.add_option("--lonmax", dest="lonmax", action="store", type="float",
                           help="max longitude in decimal degrees", default=None)
         parser.add_option("--shape", dest="shape", action="store", type="string",
-                          help="Polygon file that defines the bounding box", default=None)
+                          help="Polygon file that defines the bounding box, any format supported by geopandas", default=None)
         parser.add_option("-o", "--orbit", dest="orbit", action="store", type="int",
                           help="Orbit Path number", default=None)
         parser.add_option("--json", dest="search_json_file", action="store", type="string",
@@ -314,7 +314,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             if lat is None or lon is None:
                 if (latmin is None) or (lonmin is None) or (latmax is None) or (lonmax is None):
                     if (shape is None):
-                        raise SysError("provide at least a point or rectangle or tile number", -1)
+                        raise SysError("provide at least a point or rectangle or tile number or shape", -1)
                         # sys.exit(-1)
                     else:
                         lonmin, latmin, lonmax, latmax = gpd.read_file(shape).to_crs(4326).total_bounds
@@ -328,7 +328,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                     # sys.exit(-1)
 
         else:
-            if (latmin is None) and (lonmin is None) and (latmax is None) and (lonmax is None) and (lat is None) or (lon is None):
+            if (latmin is None) and (lonmin is None) and (latmax is None) and (lonmax is None) and (lat is None) or (lon is None) or (shape):
                 geom = 'location'
             else:
                 raise SysError("please choose location and coordinates, but not both", -1)

--- a/peps_download.py
+++ b/peps_download.py
@@ -12,8 +12,8 @@ import platform as os_platform
 
 try:
     import geopandas as gpd
-except ImportError:
-    print('Package "geopandas" could not be imported: argument "shape" will not be supported.')
+except:
+    pass
 ###########################################################################
 
 
@@ -316,12 +316,14 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                     if (shape is None):
                         raise SysError("provide at least a point or rectangle or tile number or shape", -1)
                         # sys.exit(-1)
+                    elif 'geopandas' not in sys.modules:
+                        raise SysError('Package geopandas is needed to use argument "shape".')
                     else:
                         lonmin, latmin, lonmax, latmax = gpd.read_file(shape).to_crs(4326).total_bounds
-                else:
-                    geom = 'rectangle'
+
+                geom = 'rectangle'
             else:
-                if (latmin is None) and (lonmin is None) and (latmax is None) and (lonmax is None):
+                if (latmin is None) and (lonmin is None) and (latmax is None) and (lonmax is None) and (shape is None):
                     geom = 'point'
                 else:
                     raise SysError("please choose between point and rectangle, but not both", -1)

--- a/peps_download.py
+++ b/peps_download.py
@@ -317,7 +317,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                         raise SysError("provide at least a point or rectangle or tile number or shape", -1)
                         # sys.exit(-1)
                     elif 'geopandas' not in sys.modules:
-                        raise SysError('Package geopandas is needed to use argument "shape".')
+                        raise SysError('Package geopandas is needed to use argument "shape".', -1)
                     else:
                         lonmin, latmin, lonmax, latmax = gpd.read_file(shape).to_crs(4326).total_bounds
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -257,7 +257,7 @@ def update_status(status_dict, downloaded_prod, write_dir):
     return status_dict
 
 def statistics(status_dict, message=True):
-    status = [v for k, v in status_dict]
+    status = [v for k, v in status_dict.items()]
     summary = {}
     for s in set(status):
         summary[s] = sum(status==s)

--- a/peps_download.py
+++ b/peps_download.py
@@ -259,7 +259,7 @@ def update_status(status_dict, downloaded_prod, write_dir):
 def statistics(status_dict, message=True):
     status = [v for k, v in status_dict.items()]
     summary = {}
-    for s in set(status):
+    for s in list(set(status)):
         summary[s] = sum(status==s)
     total_to_download = summary['on disk'] + summary['on tape'] + summary['staging']
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -399,7 +399,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
             search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
 
-    if os_platform.system() is 'Windows':
+    if os_platform.system() == 'Windows':
         search_catalog = search_catalog.replace('\&', '^&')
 
     print(search_catalog)
@@ -448,7 +448,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
                     search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
 
-            if os_platform.system() is 'Windows':
+            if os_platform.system() == 'Windows':
                 search_catalog = search_catalog.replace('\&', '^&')
 
             os.system(search_catalog)

--- a/peps_download.py
+++ b/peps_download.py
@@ -9,6 +9,7 @@ import sys
 import zipfile
 from datetime import date
 import platform as os_platform
+import subprocess
 
 try:
     import geopandas as gpd
@@ -79,6 +80,11 @@ class SysError(Exception):
         super().__init__(message)
     def __repr__(self):
         self.message
+
+def run_curl(x, verbose=True):
+    if not verbose:
+        x = x+' -s -S'
+    subprocess.check_call(x, shell=True)
 
 def parse_catalog(search_json_file, orbit, collection, clouds, sat, verbose=True):
     # Filter catalog result
@@ -297,7 +303,8 @@ def search_query(search_json_file, collection, product_type, sensor_mode,
             search_catalog = search_catalog.replace('\&', '^&')
         if verbose:
             print(search_catalog)
-        os.system(search_catalog)
+        run_curl(search_catalog, verbose)
+
         time.sleep(5)
 
         dl_dict, st_dict, si_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat, verbose=verbose)
@@ -520,9 +527,9 @@ def peps_download(write_dir, auth="", collection='S2', product_type="", sensor_m
                 tmpfile = ("%s/tmp_%s.tmp") % (write_dir, tmticks)
                 if verbose:
                     print("\nStage tape product: %s" % prod)
-                get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps &>/dev/null' % (
+                get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps' % (
                     tmpfile, email, passwd, collection, download_dict[prod])
-                os.system(get_product)
+                run_curl(get_product, verbose=False)
                 if os.path.exists(tmpfile):
                     os.remove(tmpfile)
 
@@ -541,7 +548,7 @@ def peps_download(write_dir, auth="", collection='S2', product_type="", sensor_m
                         tmpfile, email, passwd, collection, download_dict[prod])
                     if verbose:
                         print(get_product)
-                    os.system(get_product)
+                    run_curl(get_product, verbose)
                     # check binary product, rename tmp file
                     if os.path.exists(("%s/tmp_%s.tmp") % (write_dir, tmticks)):
                         check_rename(tmpfile, prod, size_dict[prod], write_dir, extract)

--- a/peps_download.py
+++ b/peps_download.py
@@ -12,6 +12,7 @@ import platform as os_platform
 
 try:
     import geopandas as gpd
+    import shapely
 except:
     pass
 ###########################################################################
@@ -277,8 +278,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         latitude or longitude in decimal degrees
     latmin,latmax,lonmin,lonmax: float
         bounding box of an area of interest
-    shape: str | geopandas.geodataframe.GeoDataFrame | geopandas.geoseries.GeoSeries
-        Shape file or object used to define the extent, any format supported by geopandas
+    shape: str | geopandas.geodataframe.GeoDataFrame | geopandas.geoseries.GeoSeries | shapely.geometry.polygon.Polygon | shapely.geometry.point.Point
+        Shape file or object used to define the extent. If file, any format supported by geopandas.
     orbit: int
         Orbit Path number
     search_json_file: str
@@ -327,6 +328,10 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
 
                         if isinstance(shape, (gpd.geodataframe.GeoDataFrame, gpd.geoseries.GeoSeries)):
                             lonmin, latmin, lonmax, latmax =shape.to_crs(4326).total_bounds
+                        elif isinstance(shape, shapely.geometry.polygon.Polygon):
+                            lonmin, latmin, lonmax, latmax = shape.bounds
+                        elif isinstance(shape, shapely.geometry.point.Point):
+                            lon, lat = shape.bounds
                         else:
                             raise SysError('Shape format not supported', -1)
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -23,30 +23,31 @@ class OptionParser (optparse.OptionParser):
 
 
 ###########################################################################
-def check_rename(tmpfile, prodsize, options):
+def check_rename(tmpfile, prod, prodsize, write_dir, extract):
     print(os.path.getsize(tmpfile), prodsize)
     if os.path.getsize(tmpfile) != prodsize:
         with open(tmpfile) as f_tmp:
             try:
                 tmp_data = json.load(f_tmp)
-                print("Result is a json file (might come from a wrong password file)")
+                print("Result is a json file with content:")
                 print(tmp_data)
-                sys.exit(-1)
+                raise SysError('Error might come from a wrong password file.', -1)
+                # sys.exit(-1)
             except ValueError:
                 print("\ndownload was not complete, tmp file removed")
                 os.remove(tmpfile)
                 return
 
-    zfile = "%s/%s.zip" % (options.write_dir, prod)
+    zfile = "%s/%s.zip" % (write_dir, prod)
     os.rename(tmpfile, zfile)
 
     # Unzip file
-    if options.extract and os.path.exists(zfile):
+    if extract and os.path.exists(zfile):
         try:
             with zipfile.ZipFile(zfile, 'r') as zf:
                 safename = zf.namelist()[0].replace('/', '')
-                zf.extractall(options.write_dir)
-            safedir = os.path.join(options.write_dir, safename)
+                zf.extractall(write_dir)
+            safedir = os.path.join(write_dir, safename)
             if not os.path.isdir(safedir):
                 raise Exception('Unzipped directory not found: ', zfile)
 
@@ -65,16 +66,22 @@ def check_rename(tmpfile, prodsize, options):
     print("product saved as : " + zfile)
 
 ###########################################################################
+class SysError(Exception):
+    def __init__(self, message, exit_code):
+        self.message = message
+        self.exit_code = exit_code
+        super().__init__(message)
+    def __repr__(self):
+        self.message
 
-
-def parse_catalog(search_json_file):
+def parse_catalog(search_json_file, orbit, collection, clouds, sat):
     # Filter catalog result
     with open(search_json_file) as data_file:
         data = json.load(data_file)
 
     if 'ErrorCode' in data:
-        print(data['ErrorMessage'])
-        sys.exit(-2)
+        raise SysError('file '+ search_json_file + ' contains an error:\n'+data['ErrorMessage'], -2)
+        # sys.exit(-2)
 
     # Sort data
     download_dict = {}
@@ -103,15 +110,15 @@ def parse_catalog(search_json_file):
                         # calcul de l'orbite relative pour Sentinel 1B
                         relativeOrbit = ((orbitN - 27) % 175) + 1
 
-                    if options.orbit is not None:
+                    if orbit is not None:
                         if platform.startswith('S2'):
-                            if prod.find("_R%03d" % options.orbit) > 0:
+                            if prod.find("_R%03d" % orbit) > 0:
                                 download_dict[prod] = feature_id
                                 storage_dict[prod] = storage
                                 size_dict[prod] = resourceSize
 
                         elif platform.startswith('S1'):
-                            if relativeOrbit == options.orbit:
+                            if relativeOrbit == orbit:
                                 download_dict[prod] = feature_id
                                 storage_dict[prod] = storage
                                 size_dict[prod] = resourceSize
@@ -124,17 +131,17 @@ def parse_catalog(search_json_file):
                 pass
 
         # cloud cover criterium:
-        if options.collection[0:2] == 'S2':
+        if collection[0:2] == 'S2':
             for i in range(len(data["features"])):
                 prod = data["features"][i]["properties"]["productIdentifier"]
-                if data["features"][i]["properties"]["cloudCover"] > options.clouds:
+                if data["features"][i]["properties"]["cloudCover"] > clouds:
                     del download_dict[prod], storage_dict[prod], size_dict[prod]
 
         # selecion of specific satellite
-        if options.sat != None:
+        if sat != None:
             for i in range(len(data["features"])):
                 prod = data["features"][i]["properties"]["productIdentifier"]
-                if data["features"][i]["properties"]["platform"] != options.sat:
+                if data["features"][i]["properties"]["platform"] != sat:
                     try:
                         del download_dict[prod], storage_dict[prod], size_dict[prod]
                     except KeyError:
@@ -144,7 +151,8 @@ def parse_catalog(search_json_file):
             print(prod, storage_dict[prod])
     else:
         print(">>> no product corresponds to selection criteria")
-        sys.exit(-1)
+        # sys.exit(-1)
+        return {}, {}, {}, {}
 #    print(download_dict.keys())
 
     return(prod, download_dict, storage_dict, size_dict)
@@ -154,267 +162,296 @@ def parse_catalog(search_json_file):
 # ==================
 # parse command line
 # ==================
-if len(sys.argv) == 1:
-    prog = os.path.basename(sys.argv[0])
-    print('      ' + sys.argv[0] + ' [options]')
-    print("     Aide : ", prog, " --help")
-    print("        ou : ", prog, " -h")
-    print("example 1 : python %s -l 'Toulouse' -a peps.txt -d 2016-12-06 -f 2017-02-01 -c S2ST" %
-          sys.argv[0])
-    print("example 2 : python %s --lon 1 --lat 44 -a peps.txt -d 2015-11-01 -f 2015-12-01 -c S2" %
-          sys.argv[0])
-    print("example 3 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a peps.txt -d 2015-11-01 -f 2015-12-01 -c S2" %
-          sys.argv[0])
-    print("example 4 : python %s -l 'Toulouse' -a peps.txt -c SpotWorldHeritage -p SPOT4 -d 2005-11-01 -f 2006-12-01" %
-          sys.argv[0])
-    print("example 5 : python %s -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01" %
-          sys.argv[0])
-    sys.exit(-1)
-else:
-    usage = "usage: %prog [options] "
-    parser = OptionParser(usage=usage)
 
-    parser.add_option("-l", "--location", dest="location", action="store", type="string",
-                      help="town name (pick one which is not too frequent to avoid confusions)", default=None)
-    parser.add_option("-a", "--auth", dest="auth", action="store", type="string",
-                      help="Peps account and password file")
-    parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
-                      help="Path where the products should be downloaded", default='.')
-    parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
-                      help="Collection within theia collections", choices=['S1', 'S2', 'S2ST', 'S3'], default='S2')
-    parser.add_option("-p", "--product_type", dest="product_type", action="store", type="string",
-                      help="GRD, SLC, OCN (for S1) | S2MSI1C S2MSI2A S2MSI2Ap (for S2)", default="")
-    parser.add_option("-m", "--sensor_mode", dest="sensor_mode", action="store", type="string",
-                      help="EW, IW , SM, WV (for S1) | INS-NOBS, INS-RAW (for S3)", default="")
-    parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
-                      help="Do not download products, just print curl command", default=False)
-    parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
-                      help="start date, fmt('2015-12-22')", default=None)
-    parser.add_option("-t", "--tile", dest="tile", action="store", type="string",
-                      help="Sentinel-2 tile number", default=None)
-    parser.add_option("--lat", dest="lat", action="store", type="float",
-                      help="latitude in decimal degrees", default=None)
-    parser.add_option("--lon", dest="lon", action="store", type="float",
-                      help="longitude in decimal degrees", default=None)
-    parser.add_option("--latmin", dest="latmin", action="store", type="float",
-                      help="min latitude in decimal degrees", default=None)
-    parser.add_option("--latmax", dest="latmax", action="store", type="float",
-                      help="max latitude in decimal degrees", default=None)
-    parser.add_option("--lonmin", dest="lonmin", action="store", type="float",
-                      help="min longitude in decimal degrees", default=None)
-    parser.add_option("--lonmax", dest="lonmax", action="store", type="float",
-                      help="max longitude in decimal degrees", default=None)
-    parser.add_option("-o", "--orbit", dest="orbit", action="store", type="int",
-                      help="Orbit Path number", default=None)
-    parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
-                      help="end date, fmt('2015-12-23')", default='9999-01-01')
-    parser.add_option("--json", dest="search_json_file", action="store", type="string",
-                      help="Output search JSON filename", default=None)
-    parser.add_option("--windows", dest="windows", action="store_true",
-                      help="For windows usage", default=False)
-    parser.add_option("--cc", "--clouds", dest="clouds", action="store", type="int",
-                      help="Maximum cloud coverage", default=100)
-    parser.add_option("--sat", "--satellite", dest="sat", action="store", type="string",
-                      help="S1A,S1B,S2A,S2B,S3A,S3B", default=None)
-    parser.add_option("-x", "--extract", dest="extract", action="store_true",
-                      help="Extract and remove zip file after download")
-    (options, args) = parser.parse_args()
-
-if options.search_json_file is None or options.search_json_file == "":
-    options.search_json_file = 'search.json'
-
-if options.sat != None:
-    print(options.sat, options.collection[0:2])
-    if not options.sat.startswith(options.collection[0:2]):
-        print("input parameters collection and satellite are incompatible")
+def parse_command_line():
+    if len(sys.argv) == 1:
+        prog = os.path.basename(sys.argv[0])
+        print('      ' + sys.argv[0] + ' [options]')
+        print("     Aide : ", prog, " --help")
+        print("        ou : ", prog, " -h")
+        print("example 1 : python %s -l 'Toulouse' -a peps.txt -d 2016-12-06 -f 2017-02-01 -c S2ST" %
+              sys.argv[0])
+        print("example 2 : python %s --lon 1 --lat 44 -a peps.txt -d 2015-11-01 -f 2015-12-01 -c S2" %
+              sys.argv[0])
+        print("example 3 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a peps.txt -d 2015-11-01 -f 2015-12-01 -c S2" %
+              sys.argv[0])
+        print("example 4 : python %s -l 'Toulouse' -a peps.txt -c SpotWorldHeritage -p SPOT4 -d 2005-11-01 -f 2006-12-01" %
+              sys.argv[0])
+        print("example 5 : python %s -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01" %
+              sys.argv[0])
         sys.exit(-1)
+    else:
+        usage = "usage: %prog [options] "
+        parser = OptionParser(usage=usage)
 
-if options.tile is None:
-    if options.location is None:
-        if options.lat is None or options.lon is None:
-            if (options.latmin is None) or (options.lonmin is None) or (options.latmax is None) or (options.lonmax is None):
-                print("provide at least a point or rectangle or tile number")
-                sys.exit(-1)
+        parser.add_option("-l", "--location", dest="location", action="store", type="string",
+                          help="town name (pick one which is not too frequent to avoid confusions)", default=None)
+        parser.add_option("-a", "--auth", dest="auth", action="store", type="string",
+                          help="Peps account and password file")
+        parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
+                          help="Path where the products should be downloaded", default='.')
+        parser.add_option("-c", "--collection", dest="collection", action="store", type="choice",
+                          help="Collection within theia collections", choices=['S1', 'S2', 'S2ST', 'S3'], default='S2')
+        parser.add_option("-p", "--product_type", dest="product_type", action="store", type="string",
+                          help="GRD, SLC, OCN (for S1) | S2MSI1C S2MSI2A S2MSI2Ap (for S2)", default="")
+        parser.add_option("-m", "--sensor_mode", dest="sensor_mode", action="store", type="string",
+                          help="EW, IW , SM, WV (for S1) | INS-NOBS, INS-RAW (for S3)", default="")
+        parser.add_option("-n", "--no_download", dest="no_download", action="store_true",
+                          help="Do not download products, just print curl command", default=False)
+        parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
+                          help="start date, fmt('2015-12-22')", default=None)
+        parser.add_option("-t", "--tile", dest="tile", action="store", type="string",
+                          help="Sentinel-2 tile number", default=None)
+        parser.add_option("--lat", dest="lat", action="store", type="float",
+                          help="latitude in decimal degrees", default=None)
+        parser.add_option("--lon", dest="lon", action="store", type="float",
+                          help="longitude in decimal degrees", default=None)
+        parser.add_option("--latmin", dest="latmin", action="store", type="float",
+                          help="min latitude in decimal degrees", default=None)
+        parser.add_option("--latmax", dest="latmax", action="store", type="float",
+                          help="max latitude in decimal degrees", default=None)
+        parser.add_option("--lonmin", dest="lonmin", action="store", type="float",
+                          help="min longitude in decimal degrees", default=None)
+        parser.add_option("--lonmax", dest="lonmax", action="store", type="float",
+                          help="max longitude in decimal degrees", default=None)
+        parser.add_option("-o", "--orbit", dest="orbit", action="store", type="int",
+                          help="Orbit Path number", default=None)
+        parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
+                          help="end date, fmt('2015-12-23')", default='9999-01-01')
+        parser.add_option("--json", dest="search_json_file", action="store", type="string",
+                          help="Output search JSON filename", default=None)
+        parser.add_option("--windows", dest="windows", action="store_true",
+                          help="For windows usage", default=False)
+        parser.add_option("--cc", "--clouds", dest="clouds", action="store", type="int",
+                          help="Maximum cloud coverage", default=100)
+        parser.add_option("--sat", "--satellite", dest="sat", action="store", type="string",
+                          help="S1A,S1B,S2A,S2B,S3A,S3B", default=None)
+        parser.add_option("-x", "--extract", dest="extract", action="store_true",
+                          help="Extract and remove zip file after download")
+        parser.add_option("--trials", "--trials", dest="max_trials", action="store", type="int",
+                          help="Maximum nunmber of trials when some products are on tape.", default=10)
+        parser.add_option("--wait", "--wait", dest="wait", action="store", type="int",
+                          help="Time to wait in minutes between each trial.", default=1)
+
+        (options, args) = parser.parse_args()
+
+        return options, args
+
+
+def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode="", no_download=True,
+                  start_date=None, end_date=None, tile=None, location=None,
+                  lat=None, lon=None, latmin=None, latmax=None, lonmin=None, lonmax=None,
+                  orbit=None, search_json_file=None, windows=False, clouds=100, sat=None, extract=False,
+                  max_trials=10, wait=1):
+
+    if search_json_file is None or search_json_file == "":
+        search_json_file = 'search.json'
+
+    if sat != None:
+        print(sat, collection[0:2])
+        if not sat.startswith(collection[0:2]):
+            SysError("input parameters collection and satellite are incompatible", -1)
+            # sys.exit(-1)
+
+    if tile is None:
+        if location is None:
+            if lat is None or lon is None:
+                if (latmin is None) or (lonmin is None) or (latmax is None) or (lonmax is None):
+                    raise SysError("provide at least a point or rectangle or tile number", -1)
+                    # sys.exit(-1)
+                else:
+                    geom = 'rectangle'
             else:
-                geom = 'rectangle'
+                if (latmin is None) and (lonmin is None) and (latmax is None) and (lonmax is None):
+                    geom = 'point'
+                else:
+                    raise SysError("please choose between point and rectangle, but not both", -1)
+                    # sys.exit(-1)
+
         else:
-            if (options.latmin is None) and (options.lonmin is None) and (options.latmax is None) and (options.lonmax is None):
-                geom = 'point'
+            if (latmin is None) and (lonmin is None) and (latmax is None) and (lonmax is None) and (lat is None) or (lon is None):
+                geom = 'location'
             else:
-                print("please choose between point and rectangle, but not both")
-                sys.exit(-1)
-    else:
-        if (options.latmin is None) and (options.lonmin is None) and (options.latmax is None) and (options.lonmax is None) and (options.lat is None) or (options.lon is None):
-            geom = 'location'
+                raise SysError("please choose location and coordinates, but not both", -1)
+                # sys.exit(-1)
+
+    # geometric parameters of catalog request
+
+    if tile is not None:
+        if tile.startswith('T') and len(tile) == 6:
+            tileid = tile[1:6]
+        elif len(tile) == 5:
+            tileid = tile[0:5]
         else:
-            print("please choose location and coordinates, but not both")
-            sys.exit(-1)
+            raise SysError("tile name is ill-formated : 31TCJ or T31TCJ are allowed", -4)
+            # sys.exit(-4)
+        query_geom = "tileid=%s" % (tileid)
+    elif geom == 'point':
+        query_geom = 'lat=%f\&lon=%f' % (lat, lon)
+    elif geom == 'rectangle':
+        query_geom = 'box={lonmin},{latmin},{lonmax},{latmax}'.format(
+            latmin=latmin, latmax=latmax, lonmin=lonmin, lonmax=lonmax)
+    elif geom == 'location':
+        query_geom = "q=%s" % location
 
-# geometric parameters of catalog request
-
-if options.tile is not None:
-    if options.tile.startswith('T') and len(options.tile) == 6:
-        tileid = options.tile[1:6]
-    elif len(options.tile) == 5:
-        tileid = options.tile[0:5]
-    else:
-        print("tile name is ill-formated : 31TCJ or T31TCJ are allowed")
-        sys.exit(-4)
-    query_geom = "tileid=%s" % (tileid)
-elif geom == 'point':
-    query_geom = 'lat=%f\&lon=%f' % (options.lat, options.lon)
-elif geom == 'rectangle':
-    query_geom = 'box={lonmin},{latmin},{lonmax},{latmax}'.format(
-        latmin=options.latmin, latmax=options.latmax, lonmin=options.lonmin, lonmax=options.lonmax)
-elif geom == 'location':
-    query_geom = "q=%s" % options.location
-
-# date parameters of catalog request
-if options.start_date is not None:
-    start_date = options.start_date
-    if options.end_date is not None:
-        end_date = options.end_date
-    else:
-        end_date = date.today().isoformat()
-
-# special case for Sentinel-2
-
-if options.collection == 'S2':
-    if options.start_date >= '2016-12-05':
-        print("**** products after '2016-12-05' are stored in Tiled products collection")
-        print("**** please use option -c S2ST")
-    elif options.end_date >= '2016-12-05':
-        print("**** products after '2016-12-05' are stored in Tiled products collection")
-        print("**** please use option -c S2ST to get the products after that date")
-        print("**** products before that date will be downloaded")
-
-if options.collection == 'S2ST':
-    if options.end_date < '2016-12-05':
-        print("**** products before '2016-12-05' are stored in non-tiled products collection")
-        print("**** please use option -c S2")
-    elif options.start_date < '2016-12-05':
-        print("**** products before '2016-12-05' are stored in non-tiled products collection")
-        print("**** please use option -c S2 to get the products before that date")
-        print("**** products after that date will be downloaded")
-
-# ====================
-# read authentification file
-# ====================
-try:
-    f = open(options.auth)
-    (email, passwd) = f.readline().split(' ')
-    if passwd.endswith('\n'):
-        passwd = passwd[:-1]
-    f.close()
-except:
-    print("error with password file")
-    sys.exit(-2)
-
-
-if os.path.exists(options.search_json_file):
-    os.remove(options.search_json_file)
-
-
-# ====================
-# search in catalog
-# ====================
-if (options.product_type == "") and (options.sensor_mode == ""):
-    search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500' % (
-        options.search_json_file, options.collection, query_geom, start_date, end_date)
-else:
-    search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
-        options.search_json_file, options.collection, query_geom, start_date, end_date, options.product_type, options.sensor_mode)
-
-if options.windows:
-    search_catalog = search_catalog.replace('\&', '^&')
-
-print(search_catalog)
-os.system(search_catalog)
-time.sleep(5)
-
-prod, download_dict, storage_dict, size_dict = parse_catalog(options.search_json_file)
-
-# ====================
-# Download
-# ====================
-
-
-if len(download_dict) == 0:
-    print("No product matches the criteria")
-else:
-    # first try for the products on tape
-    if options.write_dir == None:
-        options.write_dir = os.getcwd()
-
-    for prod in list(download_dict.keys()):
-        file_exists = os.path.exists(("%s/%s.SAFE") % (options.write_dir, prod)
-                                     ) or os.path.exists(("%s/%s.zip") % (options.write_dir, prod))
-        if (not(options.no_download) and not(file_exists)):
-            if storage_dict[prod] == "tape":
-                tmticks = time.time()
-                tmpfile = ("%s/tmp_%s.tmp") % (options.write_dir, tmticks)
-                print("\nStage tape product: %s" % prod)
-                get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps &>/dev/null' % (
-                    tmpfile, email, passwd, options.collection, download_dict[prod])
-                os.system(get_product)
-                if os.path.exists(tmpfile):
-                    os.remove(tmpfile)
-
-    NbProdsToDownload = len(list(download_dict.keys()))
-    print("##########################")
-    print("%d  products to download" % NbProdsToDownload)
-    print("##########################")
-    while (NbProdsToDownload > 0):
-        # redo catalog search to update disk/tape status
-        if (options.product_type == "") and (options.sensor_mode == ""):
-            search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500' % (
-                options.search_json_file, options.collection, query_geom, start_date, end_date)
+    # date parameters of catalog request
+    if start_date is not None:
+        start_date = start_date
+        if end_date is not None:
+            end_date = end_date
         else:
-            search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
-                options.search_json_file, options.collection, query_geom, start_date, end_date, options.product_type, options.sensor_mode)
+            end_date = date.today().isoformat()
 
-        if options.windows:
-            search_catalog = search_catalog.replace('\&', '^&')
+    # special case for Sentinel-2
 
-        os.system(search_catalog)
-        time.sleep(2)
+    if collection == 'S2':
+        if start_date >= '2016-12-05':
+            print("**** products after '2016-12-05' are stored in Tiled products collection")
+            print("**** please use option -c S2ST")
+        elif end_date >= '2016-12-05':
+            print("**** products after '2016-12-05' are stored in Tiled products collection")
+            print("**** please use option -c S2ST to get the products after that date")
+            print("**** products before that date will be downloaded")
 
-        prod, download_dict, storage_dict, size_dict = parse_catalog(options.search_json_file)
+    if collection == 'S2ST':
+        if end_date < '2016-12-05':
+            print("**** products before '2016-12-05' are stored in non-tiled products collection")
+            print("**** please use option -c S2")
+        elif start_date < '2016-12-05':
+            print("**** products before '2016-12-05' are stored in non-tiled products collection")
+            print("**** please use option -c S2 to get the products before that date")
+            print("**** products after that date will be downloaded")
 
-        NbProdsToDownload = 0
-        # download all products on disk
+    # ====================
+    # read authentification file
+    # ====================
+    try:
+        f = open(auth)
+        (email, passwd) = f.readline().split(' ')
+        if passwd.endswith('\n'):
+            passwd = passwd[:-1]
+        f.close()
+    except Exception as e:
+        print(e)
+        SysError("error with authentication file", -2)
+        # sys.exit(-2)
+
+
+    if os.path.exists(search_json_file):
+        os.remove(search_json_file)
+
+
+    # ====================
+    # search in catalog
+    # ====================
+    if (product_type == "") and (sensor_mode == ""):
+        search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500' % (
+            search_json_file, collection, query_geom, start_date, end_date)
+    else:
+        search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
+            search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
+
+    if windows:
+        search_catalog = search_catalog.replace('\&', '^&')
+
+    print(search_catalog)
+    os.system(search_catalog)
+    time.sleep(5)
+
+    prod, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+
+    # ====================
+    # Download
+    # ====================
+
+
+    if len(download_dict) == 0:
+        print("No product matches the criteria")
+    else:
+        # first try for the products on tape
+        if write_dir == None:
+            write_dir = os.getcwd()
+
         for prod in list(download_dict.keys()):
-            file_exists = os.path.exists(("%s/%s.SAFE") % (options.write_dir, prod)
-                                         ) or os.path.exists(("%s/%s.zip") % (options.write_dir, prod))
-            if (not(options.no_download) and not(file_exists)):
-                if storage_dict[prod] == "disk":
+            file_exists = os.path.exists(("%s/%s.SAFE") % (write_dir, prod)
+                                         ) or os.path.exists(("%s/%s.zip") % (write_dir, prod))
+            if (not(no_download) and not(file_exists)):
+                if storage_dict[prod] == "tape":
                     tmticks = time.time()
-                    tmpfile = ("%s/tmp_%s.tmp") % (options.write_dir, tmticks)
-                    print("\nDownload of product : %s" % prod)
-                    get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps' % (
-                        tmpfile, email, passwd, options.collection, download_dict[prod])
-                    print(get_product)
+                    tmpfile = ("%s/tmp_%s.tmp") % (write_dir, tmticks)
+                    print("\nStage tape product: %s" % prod)
+                    get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps &>/dev/null' % (
+                        tmpfile, email, passwd, collection, download_dict[prod])
                     os.system(get_product)
-                    # check binary product, rename tmp file
-                    if not os.path.exists(("%s/tmp_%s.tmp") % (options.write_dir, tmticks)):
+                    if os.path.exists(tmpfile):
+                        os.remove(tmpfile)
+
+        NbProdsToDownload = len(list(download_dict.keys()))
+        print("##########################")
+        print("%d  products to download" % NbProdsToDownload)
+        print("##########################")
+        n_trials = 0
+        while ((NbProdsToDownload > 0) and (n_trials < max_trials)):
+            # redo catalog search to update disk/tape status
+            if (product_type == "") and (sensor_mode == ""):
+                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500' % (
+                    search_json_file, collection, query_geom, start_date, end_date)
+            else:
+                search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
+                    search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
+
+            if windows:
+                search_catalog = search_catalog.replace('\&', '^&')
+
+            os.system(search_catalog)
+            time.sleep(2)
+
+            prod, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+
+            NbProdsToDownload = 0
+            # download all products on disk
+            for prod in list(download_dict.keys()):
+                file_exists = os.path.exists(("%s/%s.SAFE") % (write_dir, prod)
+                                             ) or os.path.exists(("%s/%s.zip") % (write_dir, prod))
+                if (not(no_download) and not(file_exists)):
+                    if storage_dict[prod] == "disk":
+                        tmticks = time.time()
+                        tmpfile = ("%s/tmp_%s.tmp") % (write_dir, tmticks)
+                        print("\nDownload of product : %s" % prod)
+                        get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps' % (
+                            tmpfile, email, passwd, collection, download_dict[prod])
+                        print(get_product)
+                        os.system(get_product)
+                        # check binary product, rename tmp file
+                        if not os.path.exists(("%s/tmp_%s.tmp") % (write_dir, tmticks)):
+                            NbProdsToDownload += 1
+                        else:
+                            check_rename(tmpfile, prod, size_dict[prod], write_dir, extract)
+
+                elif file_exists:
+                    print("%s already exists" % prod)
+
+            # download all products on tape
+            for prod in list(download_dict.keys()):
+                file_exists = os.path.exists(("%s/%s.SAFE") % (write_dir, prod)
+                                             ) or os.path.exists(("%s/%s.zip") % (write_dir, prod))
+                if (not(no_download) and not(file_exists)):
+                    if storage_dict[prod] == "tape" or storage_dict[prod] == "staging":
                         NbProdsToDownload += 1
-                    else:
-                        check_rename(tmpfile, size_dict[prod], options)
+    
+            if NbProdsToDownload > 0:
+                print("##############################################################################")
+                print("%d remaining products are on tape, lets's wait %d minutes before trying again" %
+                      NbProdsToDownload, wait)
+                print("##############################################################################")
+                time.sleep(wait*60)
 
-            elif file_exists:
-                print("%s already exists" % prod)
+if __name__ == '__main__':
 
-        # download all products on tape
-        for prod in list(download_dict.keys()):
-            file_exists = os.path.exists(("%s/%s.SAFE") % (options.write_dir, prod)
-                                         ) or os.path.exists(("%s/%s.zip") % (options.write_dir, prod))
-            if (not(options.no_download) and not(file_exists)):
-                if storage_dict[prod] == "tape" or storage_dict[prod] == "staging":
-                    NbProdsToDownload += 1
+    options, args = parse_command_line()
+    try:
+        peps_download(**vars(options))
+    except SysError as e:
+        print(e)
+        sys.exit(e.exit_code)
 
-        if NbProdsToDownload > 0:
-            print("##############################################################################")
-            print("%d remaining products are on tape, lets's wait 1 minute before trying again" %
-                  NbProdsToDownload)
-            print("##############################################################################")
-            time.sleep(60)

--- a/peps_download.py
+++ b/peps_download.py
@@ -279,7 +279,9 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     latmin,latmax,lonmin,lonmax: float
         bounding box of an area of interest
     shape: str | geopandas.geodataframe.GeoDataFrame | geopandas.geoseries.GeoSeries | shapely.geometry.polygon.Polygon | shapely.geometry.point.Point
-        Shape file or object used to define the extent. If file, any format supported by geopandas.
+        Shape file or object used to define the extent.
+        If file, any format supported by geopandas.
+        If shapely object coordinates are expected to be lon,lat (EPSG:4326)
     orbit: int
         Orbit Path number
     search_json_file: str

--- a/peps_download.py
+++ b/peps_download.py
@@ -184,8 +184,6 @@ def parse_command_line():
         usage = "usage: %prog [options] "
         parser = OptionParser(usage=usage)
 
-        parser.add_option("-l", "--location", dest="location", action="store", type="string",
-                          help="town name (pick one which is not too frequent to avoid confusions)", default=None)
         parser.add_option("-a", "--auth", dest="auth", action="store", type="string",
                           help="Peps account and password file")
         parser.add_option("-w", "--write_dir", dest="write_dir", action="store", type="string",
@@ -200,8 +198,12 @@ def parse_command_line():
                           help="Do not download products, just print curl command", default=False)
         parser.add_option("-d", "--start_date", dest="start_date", action="store", type="string",
                           help="start date, fmt('2015-12-22')", default=None)
+        parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
+                          help="end date, fmt('2015-12-23')", default='9999-01-01')
         parser.add_option("-t", "--tile", dest="tile", action="store", type="string",
                           help="Sentinel-2 tile number", default=None)
+        parser.add_option("-l", "--location", dest="location", action="store", type="string",
+                          help="town name (pick one which is not too frequent to avoid confusions)", default=None)
         parser.add_option("--lat", dest="lat", action="store", type="float",
                           help="latitude in decimal degrees", default=None)
         parser.add_option("--lon", dest="lon", action="store", type="float",
@@ -216,8 +218,6 @@ def parse_command_line():
                           help="max longitude in decimal degrees", default=None)
         parser.add_option("-o", "--orbit", dest="orbit", action="store", type="int",
                           help="Orbit Path number", default=None)
-        parser.add_option("-f", "--end_date", dest="end_date", action="store", type="string",
-                          help="end date, fmt('2015-12-23')", default='9999-01-01')
         parser.add_option("--json", dest="search_json_file", action="store", type="string",
                           help="Output search JSON filename", default=None)
         parser.add_option("--windows", dest="windows", action="store_true",

--- a/peps_download.py
+++ b/peps_download.py
@@ -502,7 +502,10 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         for prod in products:
             file_exists = os.path.exists(("%s/%s.SAFE") % (write_dir, prod)
                                          ) or os.path.exists(("%s/%s.zip") % (write_dir, prod))
-            if not(file_exists):
+            if file_exists:
+                print("%s already exists" % prod)
+                NbProdsDownloaded += 1
+            else:
                 if storage_dict[prod] == "disk":
                     tmticks = time.time()
                     tmpfile = ("%s/tmp_%s.tmp") % (write_dir, tmticks)
@@ -517,10 +520,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                     else:
                         check_rename(tmpfile, prod, size_dict[prod], write_dir, extract)
                     NbProdsDownloaded += 1
-            elif file_exists:
-                print("%s already exists" % prod)
-                NbProdsDownloaded += 1
-            elif storage_dict[prod] == "tape" or storage_dict[prod] == "staging":
+
+                elif storage_dict[prod] == "tape" or storage_dict[prod] == "staging":
                     NbProdsToDownload += 1
 
         # download all products on tape

--- a/peps_download.py
+++ b/peps_download.py
@@ -8,6 +8,7 @@ import optparse
 import sys
 import zipfile
 from datetime import date
+import platform as os_platform
 
 ###########################################################################
 
@@ -220,8 +221,6 @@ def parse_command_line():
                           help="Orbit Path number", default=None)
         parser.add_option("--json", dest="search_json_file", action="store", type="string",
                           help="Output search JSON filename", default=None)
-        parser.add_option("--windows", dest="windows", action="store_true",
-                          help="For windows usage", default=False)
         parser.add_option("--cc", "--clouds", dest="clouds", action="store", type="int",
                           help="Maximum cloud coverage", default=100)
         parser.add_option("--sat", "--satellite", dest="sat", action="store", type="string",
@@ -241,7 +240,7 @@ def parse_command_line():
 def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode="", no_download=True,
                   start_date=None, end_date=None, tile=None, location=None,
                   lat=None, lon=None, latmin=None, latmax=None, lonmin=None, lonmax=None,
-                  orbit=None, search_json_file=None, windows=False, clouds=100, sat=None, extract=False,
+                  orbit=None, search_json_file=None, clouds=100, sat=None, extract=False,
                   max_trials=10, wait=1):
     """
     Download Sentinel S1, S2 or S3 products from PEPS sever
@@ -276,8 +275,6 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         Orbit Path number
     search_json_file: str
         Output search JSON file path
-    windows: bool
-        For windows usage
     clouds: int
         Maximum cloud coverage
     sat: str
@@ -402,7 +399,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
             search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
 
-    if windows:
+    if os_platform.system() is 'Windows':
         search_catalog = search_catalog.replace('\&', '^&')
 
     print(search_catalog)
@@ -451,7 +448,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 search_catalog = 'curl -k -o %s https://peps.cnes.fr/resto/api/collections/%s/search.json?%s\&startDate=%s\&completionDate=%s\&maxRecords=500\&productType=%s\&sensorMode=%s' % (
                     search_json_file, collection, query_geom, start_date, end_date, product_type, sensor_mode)
 
-            if windows:
+            if os_platform.system() is 'Windows':
                 search_catalog = search_catalog.replace('\&', '^&')
 
             os.system(search_catalog)

--- a/peps_download.py
+++ b/peps_download.py
@@ -419,7 +419,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     os.system(search_catalog)
     time.sleep(5)
 
-    prod, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+    products, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
 
     # ====================
     # Download

--- a/peps_download.py
+++ b/peps_download.py
@@ -164,7 +164,7 @@ def parse_catalog(search_json_file, orbit, collection, clouds, sat, verbose=True
     else:
         print(">>> no product corresponds to selection criteria")
         # sys.exit(-1)
-        return {}, {}, {}, {}
+        return {}, {}, {}
 #    print(download_dict.keys())
 
     return(download_dict, status_dict, size_dict)

--- a/peps_download.py
+++ b/peps_download.py
@@ -305,7 +305,7 @@ def search_query(search_json_file, collection, product_type, sensor_mode,
             print(search_catalog)
         run_curl(search_catalog, verbose)
 
-        time.sleep(5)
+        # time.sleep(1)
 
         dl_dict, st_dict, si_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat, verbose=verbose)
         download_dict.update(dl_dict)

--- a/peps_download.py
+++ b/peps_download.py
@@ -508,7 +508,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 time.sleep(wait*60)
 
 
-        return download_dict.keys()
+        return(prod, download_dict.keys())
 
 if __name__ == '__main__':
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -493,7 +493,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             if (NbProdsToDownload > 0) and (n_trials < max_trials):
                 print("##############################################################################")
                 print("%d remaining products are on tape, lets's wait %d minutes before trying again" %
-                      NbProdsToDownload, wait)
+                      (NbProdsToDownload, wait))
                 print("##############################################################################")
                 time.sleep(wait*60)
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -420,7 +420,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     time.sleep(5)
 
     download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
-    products = download_dict.keys()
+    products = list(download_dict.keys())
 
     # ====================
     # Download

--- a/peps_download.py
+++ b/peps_download.py
@@ -489,13 +489,14 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 if (not(no_download) and not(file_exists)):
                     if storage_dict[prod] == "tape" or storage_dict[prod] == "staging":
                         NbProdsToDownload += 1
-    
-            if NbProdsToDownload > 0:
+            n_trials += 1
+            if (NbProdsToDownload > 0) and (n_trials < max_trials):
                 print("##############################################################################")
                 print("%d remaining products are on tape, lets's wait %d minutes before trying again" %
                       NbProdsToDownload, wait)
                 print("##############################################################################")
                 time.sleep(wait*60)
+
 
         return download_dict.keys()
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -326,16 +326,18 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                             else:
                                 raise SysError('Shape file not found', -1)
 
+                        geom = 'rectangle'
+
                         if isinstance(shape, (gpd.geodataframe.GeoDataFrame, gpd.geoseries.GeoSeries)):
                             lonmin, latmin, lonmax, latmax =shape.to_crs(4326).total_bounds
                         elif isinstance(shape, shapely.geometry.polygon.Polygon):
                             lonmin, latmin, lonmax, latmax = shape.bounds
                         elif isinstance(shape, shapely.geometry.point.Point):
                             lon, lat = shape.bounds
+                            geom = 'point'
                         else:
                             raise SysError('Shape format not supported', -1)
 
-                geom = 'rectangle'
             else:
                 if (latmin is None) and (lonmin is None) and (latmax is None) and (lonmax is None) and (shape is None):
                     geom = 'point'

--- a/peps_download.py
+++ b/peps_download.py
@@ -146,7 +146,7 @@ def parse_catalog(search_json_file, orbit, collection, clouds, sat, verbose=True
         if collection[0:2] == 'S2':
             for i in range(len(data["features"])):
                 prod = data["features"][i]["properties"]["productIdentifier"]
-                if data["features"][i]["properties"]["cloudCover"] > clouds:
+                if data["features"][i]["properties"]["cloudCover"] is not None and data["features"][i]["properties"]["cloudCover"] > clouds:
                     del download_dict[prod], status_dict[prod], size_dict[prod]
 
         # selecion of specific satellite

--- a/peps_download.py
+++ b/peps_download.py
@@ -187,8 +187,7 @@ def parse_command_line():
               sys.argv[0])
         print("example 3 : python %s --lonmin 1 --lonmax 2 --latmin 43 --latmax 44 -a peps.txt -d 2015-11-01 -f 2015-12-01 -c S2" %
               sys.argv[0])
-
-        print("example 5 : python %s -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01" %
+        print("example 4 : python %s -c S1 -p GRD -l 'Toulouse' -a peps.txt -d 2015-11-01 -f 2015-12-01" %
               sys.argv[0])
         sys.exit(-1)
     else:

--- a/peps_download.py
+++ b/peps_download.py
@@ -447,7 +447,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         dl_dict, st_dict, si_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
         download_dict.update(dl_dict)
         storage_dict.update(st_dict)
-        size_dict.update(size_dict)
+        size_dict.update(si_dict)
         page_len = len(dl_dict)
 
     products=list(download_dict.keys())
@@ -460,7 +460,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
 
     if len(download_dict) == 0:
         print("No product matches the criteria")
-        return ([], [])
+        return []
 
     if no_download:
         return products
@@ -515,7 +515,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             dl_dict, st_dict, si_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
             download_dict.update(dl_dict)
             storage_dict.update(st_dict)
-            size_dict.update(size_dict)
+            size_dict.update(si_dict)
             page_len = len(dl_dict)
 
         products = list(download_dict.keys())
@@ -553,7 +553,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             time.sleep(wait*60)
 
 
-    return products, download_dict.keys()
+    return products
 
 if __name__ == '__main__':
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -498,7 +498,7 @@ def peps_download(write_dir, auth="", collection='S2', product_type="", sensor_m
 
     if len(download_dict) == 0:
         print("No product matches the criteria")
-        return []
+        return {}
 
     summary, total_to_download = statistics(status_dict, message=verbose)
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -259,9 +259,9 @@ def update_status(status_dict, downloaded_prod, write_dir):
 def statistics(status_dict, message=True):
     status = [v for k, v in status_dict.items()]
     summary = {}
-    for s in list(set(status)):
-        summary[s] = sum(status==s)
-    total_to_download = summary['on disk'] + summary['on tape'] + summary['staging']
+    for s in set(status):
+        summary[s] = sum([v == s for v in status])
+        total_to_download = summary['on disk'] + summary['on tape'] + summary['staging']
 
     if message:
         print("###################################################")

--- a/peps_download.py
+++ b/peps_download.py
@@ -469,10 +469,13 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     if write_dir == None:
         write_dir = os.getcwd()
 
+    NbProdsDownloaded = 0
     for prod in products:
         file_exists = os.path.exists(("%s/%s.SAFE") % (write_dir, prod)
                                      ) or os.path.exists(("%s/%s.zip") % (write_dir, prod))
-        if (not(no_download) and not(file_exists)):
+        if file_exists:
+            NbProdsDownloaded += 1
+        else:
             if storage_dict[prod] == "tape":
                 tmticks = time.time()
                 tmpfile = ("%s/tmp_%s.tmp") % (write_dir, tmticks)
@@ -483,12 +486,17 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 if os.path.exists(tmpfile):
                     os.remove(tmpfile)
 
-    NbProdsToDownload = len(list(download_dict.keys()))
-    print("##########################")
-    print("%d  products to download" % NbProdsToDownload)
-    print("##########################")
+
+    NbProdsToDownload = len(list(download_dict)) - NbProdsDownloaded
+    print("###################################################")
+    print('%d products already downloaded' % NbProdsDownloaded)
+    print("%d remaining products to download" % NbProdsToDownload)
+    print("###################################################")
+
     n_trials = 0
     while ((NbProdsToDownload > 0) and (n_trials < max_trials)):
+
+        NbProdsDownloaded = 0
         NbProdsToDownload = 0
         # download all products on disk
         for prod in products:
@@ -508,8 +516,10 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                         NbProdsToDownload += 1
                     else:
                         check_rename(tmpfile, prod, size_dict[prod], write_dir, extract)
+                    NbProdsDownloaded += 1
             elif file_exists:
                 print("%s already exists" % prod)
+                NbProdsDownloaded += 1
             elif storage_dict[prod] == "tape" or storage_dict[prod] == "staging":
                     NbProdsToDownload += 1
 
@@ -517,6 +527,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         n_trials += 1
         if (NbProdsToDownload > 0) and (n_trials < max_trials):
             print("##############################################################################")
+            print('%d products already downloaded' % NbProdsDownloaded)
             print("%d remaining products are on tape, lets's wait %d minutes before trying again" %
                   (NbProdsToDownload, wait))
             print("##############################################################################")

--- a/peps_download.py
+++ b/peps_download.py
@@ -454,4 +454,6 @@ if __name__ == '__main__':
     except SysError as e:
         print(e)
         sys.exit(e.exit_code)
+    except Exception as e:
+        raise e
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -313,7 +313,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                   start_date=None, end_date=None, tile=None, location=None,
                   lat=None, lon=None, latmin=None, latmax=None, lonmin=None, lonmax=None, shape=None,
                   orbit=None, search_json_file=None, clouds=100, sat=None, extract=True,
-                  max_trials=10, wait=1):
+                  max_trials=10, wait=1, verbose=True):
     """
     Download Sentinel S1, S2 or S3 products from PEPS sever
 
@@ -512,7 +512,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             if status_dict[prod] == "on tape":
                 tmticks = time.time()
                 tmpfile = ("%s/tmp_%s.tmp") % (write_dir, tmticks)
-                print("\nStage tape product: %s" % prod)
+                if verbose:
+                    print("\nStage tape product: %s" % prod)
                 get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps &>/dev/null' % (
                     tmpfile, email, passwd, collection, download_dict[prod])
                 os.system(get_product)
@@ -528,10 +529,12 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 if status_dict[prod] == 'on disk':
                     tmticks = time.time()
                     tmpfile = ("%s/tmp_%s.tmp") % (write_dir, tmticks)
-                    print("\nDownload of product : %s" % prod)
+                    if verbose:
+                        print("\nDownload of product : %s" % prod)
                     get_product = 'curl -o %s -k -u "%s:%s" https://peps.cnes.fr/resto/collections/%s/%s/download/?issuerId=peps' % (
                         tmpfile, email, passwd, collection, download_dict[prod])
-                    print(get_product)
+                    if verbose:
+                        print(get_product)
                     os.system(get_product)
                     # check binary product, rename tmp file
                     if os.path.exists(("%s/tmp_%s.tmp") % (write_dir, tmticks)):

--- a/peps_download.py
+++ b/peps_download.py
@@ -505,7 +505,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
         print("No product matches the criteria")
         return []
 
-    summary, total_to_download = statistics(status_dict, message=True)
+    summary, total_to_download = statistics(status_dict, message=verbose)
 
     if not no_download:
         # first try for the products on tape
@@ -548,7 +548,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
 
 
             # download all products on tape
-            summary, total_to_download = statistics(status_dict, message=True)
+            summary, total_to_download = statistics(status_dict, message=verbose)
 
             n_trials += 1
             if (total_to_download > 0) and (n_trials < max_trials):

--- a/peps_download.py
+++ b/peps_download.py
@@ -467,7 +467,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
             os.system(search_catalog)
             time.sleep(2)
 
-            prod, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
+            products, download_dict, storage_dict, size_dict = parse_catalog(search_json_file, orbit, collection, clouds, sat)
 
             NbProdsToDownload = 0
             # download all products on disk
@@ -508,7 +508,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 time.sleep(wait*60)
 
 
-    return(prod, download_dict.keys())
+    return(products, download_dict.keys())
 
 if __name__ == '__main__':
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -362,8 +362,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
 
     Returns
     -------
-    list
-        Product names
+    dict
+        {product name: status}
     """
 
     if search_json_file is None or search_json_file == "":

--- a/peps_download.py
+++ b/peps_download.py
@@ -508,7 +508,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                 time.sleep(wait*60)
 
 
-        return(prod, download_dict.keys())
+    return(prod, download_dict.keys())
 
 if __name__ == '__main__':
 

--- a/peps_download.py
+++ b/peps_download.py
@@ -222,7 +222,7 @@ def parse_command_line():
         parser.add_option("--lonmax", dest="lonmax", action="store", type="float",
                           help="max longitude in decimal degrees", default=None)
         parser.add_option("--shape", dest="shape", action="store", type="string",
-                          help="Polygon file that defines the bounding box, any format supported by geopandas", default=None)
+                          help="Shape file that defines the bounding box, any format supported by geopandas", default=None)
         parser.add_option("-o", "--orbit", dest="orbit", action="store", type="int",
                           help="Orbit Path number", default=None)
         parser.add_option("--json", dest="search_json_file", action="store", type="string",
@@ -278,7 +278,7 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
     latmin,latmax,lonmin,lonmax: float
         bounding box of an area of interest
     shape: str
-        Polygon file used to define the extent
+        Shape file used to define the extent, any format supported by geopandas
     orbit: int
         Orbit Path number
     search_json_file: str

--- a/peps_download.py
+++ b/peps_download.py
@@ -243,6 +243,57 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                   lat=None, lon=None, latmin=None, latmax=None, lonmin=None, lonmax=None,
                   orbit=None, search_json_file=None, windows=False, clouds=100, sat=None, extract=False,
                   max_trials=10, wait=1):
+    """
+    Download Sentinel S1, S2 or S3 products from PEPS sever
+
+    Parameters
+    ----------
+    write_dir: str
+        Download directory
+    auth: str
+        Authentication file with Peps account and password
+    collection: str
+        Collection within theia collections: 'S1', 'S2', 'S2ST', 'S3'
+    product_type: str
+        GRD, SLC, OCN (for S1) | S2MSI1C S2MSI2A S2MSI2Ap (for S2)
+    sensor_mode:
+        EW, IW , SM, WV (for S1) | INS-NOBS, INS-RAW (for S3)
+    no_download: bool
+        Do not download products, just print curl command results
+    start_date: str
+        start date, in the format '2015-12-22'
+    end_date: str
+        end date, in the format '2015-12-22'
+    tile: str
+        Sentinel-2 tile number, e.g. 31TCJ or T31TCJ are allowed
+    location: str
+        town name, e.g. 'Toulouse'
+    lat,lon: float
+        latitude or longitude in decimal degrees
+    latmin,latmax,lonmin,lonmax: float
+        bounding box of an area of interest
+    orbit: int
+        Orbit Path number
+    search_json_file: str
+        Output search JSON file path
+    windows: bool
+        For windows usage
+    clouds: int
+        Maximum cloud coverage
+    sat: str
+        S1A,S1B,S2A,S2B,S3A,S3B
+    extract: bool
+        If True, extract and remove zip file after download
+    max_trials: int
+        Maximum number of trials before it stops although files are still not downloaded (on tape or staging)
+    wait: int
+        Number of minutes to wait between trials.
+
+    Returns
+    -------
+    list
+        Product names
+    """
 
     if search_json_file is None or search_json_file == "":
         search_json_file = 'search.json'
@@ -445,6 +496,8 @@ def peps_download(write_dir, auth, collection='S2', product_type="", sensor_mode
                       NbProdsToDownload, wait)
                 print("##############################################################################")
                 time.sleep(wait*60)
+
+        return download_dict.keys()
 
 if __name__ == '__main__':
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,103 @@
+from setuptools import setup, find_packages
+from codecs import open  # To use a consistent encoding
+import os.path
+
+here = os.path.abspath(os.path.dirname(__file__))
+NAME = 'peps_download'
+# Read the version from the relevant file
+# with open(os.path.join(here, 'VERSION'), encoding='utf-8') as f:
+#     version = f.readline()
+# version = version.rstrip('\n')
+
+setup(
+    name=NAME,
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='1.0.0',
+
+    description="Python API to download products from  [PEPS](https://peps.cnes.fr)",
+    long_description='Python API to download products from  [PEPS](https://peps.cnes.fr)',
+
+    # Project's main homepage.
+    url='https://github.com/olivierhagolle/peps_download',
+
+    # Author details
+    author='Olivier Hagolle',
+    author_email='olivier.hagolle@cesbio.cnes.fr',
+
+    # License
+    # license='GPLv3',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # Project maturity:
+        #   2 - Pre-Alpha
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 4 - Beta',
+
+        # Execution environment
+        'Environment :: Console',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: GIS',
+        'Topic :: Scientific/Engineering :: Information Analysis',
+
+        # License
+        # 'License :: OSI Approved :: '
+        # 'GNU General Public License v3 or later (GPLv3+)',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+    ],
+
+    # What does your project relate to?
+    keywords=['CNES', 'Sentinel', 'Remote Sensing'],
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    # find_packages(exclude=['doc', 'tests', 'scripts', 'examples']),
+    # packages=find_packages(),
+
+    # List run-time dependencies here.  These will be installed by pip when your
+    # project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=[],
+
+    # List additional groups of dependencies here (e.g. dev dependencies).
+    # You can install these using the following syntax, for example:
+    # $ pip install -e .[dev,test]
+    extras_require={},
+
+    # If there are data files included in your packages that need to be
+    # installed, specify them here.  If using Python 2.6 or less, then these
+    # have to be included in MANIFEST.in as well.
+    package_data={},  # 'pytools4dart/templates':'templates/plots.xml'
+    include_package_data=True,
+
+    # Although 'package_data' is the preferred approach, in some case you may
+    # need to place data files outside of your packages.
+    # see
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
+    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+    data_files=[],  # ('templates', ['templates/plots.xml'])
+
+    # Where to find tests
+    # test_suite="tests",
+
+    # To provide executable scripts, use entry points in preference to the
+    # "scripts" keyword. Entry points provide cross-platform support and allow
+    # pip to create the appropriate form of executable for the target platform.
+    scripts=['peps_download.py'],
+
+    py_modules=['peps_download'],
+
+)


### PR DESCRIPTION
Hi Olivier,
I made several enhancements to peps_download after packaging, see below list. I tried to keep as much as possible as your code.
Although geopandas is supported, it is not required. If not available, setting shape argument will just raise an error.

You can install and try the package with command line:
```
pip install git+https://github.com/floriandeboissieu/peps_download.git@shapefile
```

# v1.0.0
## Add

- pip install support
- multipage requests
- argument shape as file (shapefile, geojson, ...), shapely geometry, or geopandas object to define bounding box
- control of verbosity
- NEWS.md for future updates

# Change

- return file status ('on tape', 'staging', 'on disk', 'downloaded', 'existing')
- update README
 

